### PR TITLE
upgrade go to 1.24.6 for vul: GO-2025-3849

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aarondl/sqlboiler/v4
 
-go 1.23.0
+go 1.24.6
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1


### PR DESCRIPTION
Context: https://pkg.go.dev/vuln/GO-2025-3849