### PR TITLE
Do not treat columns with partial unique indexes as unique in psql driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Do not treat columns with partial unique indexes as unique in psql driver.
+
 ## [4.19.1] - 2025-05-20
 
 ### Fixed

--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/aarondl/sqlboiler/v4/importers"
 
-	"github.com/aarondl/strmangle"
 	"github.com/friendsofgo/errors"
+	"github.com/aarondl/strmangle"
 
 	"github.com/aarondl/sqlboiler/v4/drivers"
 
@@ -390,10 +390,7 @@ select * from results;
 	return nil
 }
 
-func (p *PostgresDriver) ViewColumns(schema, tableName string, whitelist, blacklist []string) (
-	[]drivers.Column,
-	error,
-) {
+func (p *PostgresDriver) ViewColumns(schema, tableName string, whitelist, blacklist []string) ([]drivers.Column, error) {
 	return p.Columns(schema, tableName, whitelist, blacklist)
 }
 
@@ -604,7 +601,7 @@ func (p *PostgresDriver) Columns(schema, tableName string, whitelist, blacklist 
 			}
 		}
 	}
-
+	
 	if len(blacklist) > 0 {
 		cols := drivers.ColumnsFromList(blacklist, tableName)
 		if len(cols) > 0 {

--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/aarondl/sqlboiler/v4/importers"
 
-	"github.com/friendsofgo/errors"
 	"github.com/aarondl/strmangle"
+	"github.com/friendsofgo/errors"
 
 	"github.com/aarondl/sqlboiler/v4/drivers"
 
@@ -365,7 +365,7 @@ method_b as (
     inner join pg_class pgc on pgix.indexname = pgc.relname and pgc.relkind = 'i' and pgc.relnatts = 1
     inner join pg_index pgi on pgi.indexrelid = pgc.oid
     inner join pg_attribute pga on pga.attrelid = pgi.indrelid and pga.attnum = ANY(pgi.indkey)
-    where pgi.indisunique = true
+    where pgi.indisunique = true and pgi.indpred is null
 ),
 results as (
     select * from method_a
@@ -390,7 +390,10 @@ select * from results;
 	return nil
 }
 
-func (p *PostgresDriver) ViewColumns(schema, tableName string, whitelist, blacklist []string) ([]drivers.Column, error) {
+func (p *PostgresDriver) ViewColumns(schema, tableName string, whitelist, blacklist []string) (
+	[]drivers.Column,
+	error,
+) {
 	return p.Columns(schema, tableName, whitelist, blacklist)
 }
 
@@ -601,7 +604,7 @@ func (p *PostgresDriver) Columns(schema, tableName string, whitelist, blacklist 
 			}
 		}
 	}
-	
+
 	if len(blacklist) > 0 {
 		cols := drivers.ColumnsFromList(blacklist, tableName)
 		if len(cols) > 0 {


### PR DESCRIPTION
This PR fixes a bug in the psql driver where partial unique indexes will mark a column as unique, which is not true as it is only unique over a subset of rows. This currently leads to bugs such as #1436 where incorrect relations are generated (one-to-one instead of one-to-many) but could potentially also lead to other bugs where this difference is important.

This fix is implemented by adding a condition to the query in `*PostgresDriver.loadUniqueColumns` that excludes partial indexes by filtering on the `pg_index.indpred` column which will be null if it is not a partial index as stated in the [PostgreSQL docs:](https://www.postgresql.org/docs/current/catalog-pg-index.html)
> indpred pg_node_tree
> Expression tree (in nodeToString() representation) for partial index predicate. Null if not a partial index.