### PR TITLE
Fix buffer reuse for types.JSON fields

### DIFF
--- a/queries/reflect.go
+++ b/queries/reflect.go
@@ -240,11 +240,6 @@ func bind(rows *sql.Rows, obj any, structType, sliceType reflect.Type, bkind bin
 		return err
 	}
 
-	var oneStruct reflect.Value
-	if bkind == kindSliceStruct {
-		oneStruct = reflect.Indirect(reflect.New(structType))
-	}
-
 	foundOne := false
 Rows:
 	for rows.Next() {
@@ -256,7 +251,8 @@ Rows:
 		case kindStruct:
 			pointers = PtrsFromMapping(reflect.Indirect(reflect.ValueOf(obj)), mapping)
 		case kindSliceStruct:
-			pointers = PtrsFromMapping(oneStruct, mapping)
+			newStruct = reflect.Indirect(reflect.New(structType))
+			pointers = PtrsFromMapping(newStruct, mapping)
 		case kindPtrSliceStruct:
 			newStruct = makeStructPtr(structType)
 			pointers = PtrsFromMapping(reflect.Indirect(newStruct), mapping)
@@ -272,9 +268,7 @@ Rows:
 		switch bkind {
 		case kindStruct:
 			break Rows
-		case kindSliceStruct:
-			ptrSlice.Set(reflect.Append(ptrSlice, oneStruct))
-		case kindPtrSliceStruct:
+		case kindSliceStruct, kindPtrSliceStruct:
 			ptrSlice.Set(reflect.Append(ptrSlice, newStruct))
 		}
 	}

--- a/queries/reflect_test.go
+++ b/queries/reflect_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aarondl/null/v8"
 	"github.com/aarondl/sqlboiler/v4/drivers"
+	"github.com/aarondl/sqlboiler/v4/types"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
@@ -173,6 +174,57 @@ func TestBindPtrSlice(t *testing.T) {
 		t.Error("wrong ID:", id)
 	}
 	if name := testResults[1].Name; name != "cat" {
+		t.Error("wrong name:", name)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestBindJsonSlice(t *testing.T) {
+	t.Parallel()
+
+	type siteInfoItem struct {
+		ID     int        `boil:"id"   json:"id"   toml:"id"   yaml:"id"`
+		Fields types.JSON `boil:"test" json:"test" toml:"test" yaml:"test"`
+	}
+
+	query := &Query{
+		from:    []string{"fun"},
+		dialect: &drivers.Dialect{LQ: '"', RQ: '"', UseIndexPlaceholders: true},
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Error(err)
+	}
+
+	ret := sqlmock.NewRows([]string{"id", "test"})
+	ret.AddRow(driver.Value(int64(35)), driver.Value(`{"foo": "bar"}`))
+	ret.AddRow(driver.Value(int64(12)), driver.Value("{}"))
+	mock.ExpectQuery(`SELECT \* FROM "fun";`).WillReturnRows(ret)
+
+	var testResults []siteInfoItem
+	err = query.Bind(nil, db, &testResults)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(testResults) != 2 {
+		t.Fatal("wrong number of results:", len(testResults))
+	}
+	if id := testResults[0].ID; id != 35 {
+		t.Error("wrong ID:", id)
+	}
+	if name := testResults[0].Fields; name.String() != `{"foo": "bar"}` {
+		t.Error("wrong name:", name)
+	}
+
+	if id := testResults[1].ID; id != 12 {
+		t.Error("wrong ID:", id)
+	}
+	if name := testResults[1].Fields; name.String() != "{}" {
 		t.Error("wrong name:", name)
 	}
 


### PR DESCRIPTION
* 8b2fd83 The test case is cherry picked from https://github.com/aarondl/sqlboiler/pull/1426
* b5b94dd Fixes the buffer reuse
* 7f8daf077 Cleans up `sliceType` usage because bind doesn't need it anymore, drops a redundant `err` check.

We create a new instance of `newStruct` instead of reusing the previous `oneStruct`
Ensures memory is not shared between slice elements.

The tests from #1426 pass on this branch
```
go test github.com/aarondl/sqlboiler/v4/queries -run "TestBindJsonSlice"
```