### PR TITLE
fix(psql): map integer/serial to int32 instead of int

### DIFF
--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -785,7 +785,7 @@ func (p *PostgresDriver) TranslateColumnType(c drivers.Column) drivers.Column {
 		case "bigint", "bigserial":
 			c.Type = "null.Int64"
 		case "integer", "serial":
-			c.Type = "null.Int"
+			c.Type = "null.Int32"
 		case "oid":
 			c.Type = "null.Uint32"
 		case "smallint", "smallserial":
@@ -850,7 +850,7 @@ func (p *PostgresDriver) TranslateColumnType(c drivers.Column) drivers.Column {
 		case "bigint", "bigserial":
 			c.Type = "int64"
 		case "integer", "serial":
-			c.Type = "int"
+			c.Type = "int32"
 		case "oid":
 			c.Type = "uint32"
 		case "smallint", "smallserial":

--- a/drivers/sqlboiler-psql/driver/psql.golden.enums.json
+++ b/drivers/sqlboiler-psql/driver/psql.golden.enums.json
@@ -7,7 +7,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -22,7 +22,7 @@
 				},
 				{
 					"name": "parent_id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -37,7 +37,7 @@
 				},
 				{
 					"name": "root_id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -139,7 +139,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "nextval('sponsors_id_seq'::regclass)",
 					"comment": "",
@@ -187,7 +187,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "nextval('tags_id_seq'::regclass)",
 					"comment": "",
@@ -245,7 +245,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "nextval('type_monsters_id_seq'::regclass)",
 					"comment": "",
@@ -905,7 +905,7 @@
 				},
 				{
 					"name": "int_zero",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -920,7 +920,7 @@
 				},
 				{
 					"name": "int_one",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -935,7 +935,7 @@
 				},
 				{
 					"name": "int_two",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -950,7 +950,7 @@
 				},
 				{
 					"name": "int_three",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "333333",
 					"comment": "",
@@ -965,7 +965,7 @@
 				},
 				{
 					"name": "int_four",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "444444",
 					"comment": "",
@@ -980,7 +980,7 @@
 				},
 				{
 					"name": "int_five",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "0",
 					"comment": "",
@@ -995,7 +995,7 @@
 				},
 				{
 					"name": "int_six",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "0",
 					"comment": "",
@@ -1670,7 +1670,7 @@
 				},
 				{
 					"name": "integer_default",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "5",
 					"comment": "",
@@ -2651,7 +2651,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "nextval('users_id_seq'::regclass)",
 					"comment": "",
@@ -2739,7 +2739,7 @@
 			"columns": [
 				{
 					"name": "video_id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -2754,7 +2754,7 @@
 				},
 				{
 					"name": "tag_id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -2814,7 +2814,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "nextval('videos_id_seq'::regclass)",
 					"comment": "",
@@ -2829,7 +2829,7 @@
 				},
 				{
 					"name": "user_id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -2844,7 +2844,7 @@
 				},
 				{
 					"name": "sponsor_id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -2925,7 +2925,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3585,7 +3585,7 @@
 				},
 				{
 					"name": "int_zero",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3600,7 +3600,7 @@
 				},
 				{
 					"name": "int_one",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3615,7 +3615,7 @@
 				},
 				{
 					"name": "int_two",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3630,7 +3630,7 @@
 				},
 				{
 					"name": "int_three",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3645,7 +3645,7 @@
 				},
 				{
 					"name": "int_four",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3660,7 +3660,7 @@
 				},
 				{
 					"name": "int_five",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3675,7 +3675,7 @@
 				},
 				{
 					"name": "int_six",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -4350,7 +4350,7 @@
 				},
 				{
 					"name": "integer_default",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -5326,7 +5326,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -5986,7 +5986,7 @@
 				},
 				{
 					"name": "int_zero",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6001,7 +6001,7 @@
 				},
 				{
 					"name": "int_one",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6016,7 +6016,7 @@
 				},
 				{
 					"name": "int_two",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6031,7 +6031,7 @@
 				},
 				{
 					"name": "int_three",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6046,7 +6046,7 @@
 				},
 				{
 					"name": "int_four",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6061,7 +6061,7 @@
 				},
 				{
 					"name": "int_five",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6076,7 +6076,7 @@
 				},
 				{
 					"name": "int_six",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6751,7 +6751,7 @@
 				},
 				{
 					"name": "integer_default",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -7727,7 +7727,7 @@
 			"columns": [
 				{
 					"name": "user_id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -7742,7 +7742,7 @@
 				},
 				{
 					"name": "video_id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -7757,7 +7757,7 @@
 				},
 				{
 					"name": "sponsor_id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",

--- a/drivers/sqlboiler-psql/driver/psql.golden.json
+++ b/drivers/sqlboiler-psql/driver/psql.golden.json
@@ -7,7 +7,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -22,7 +22,7 @@
 				},
 				{
 					"name": "parent_id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -37,7 +37,7 @@
 				},
 				{
 					"name": "root_id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -139,7 +139,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "nextval('sponsors_id_seq'::regclass)",
 					"comment": "",
@@ -187,7 +187,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "nextval('tags_id_seq'::regclass)",
 					"comment": "",
@@ -245,7 +245,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "nextval('type_monsters_id_seq'::regclass)",
 					"comment": "",
@@ -905,7 +905,7 @@
 				},
 				{
 					"name": "int_zero",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -920,7 +920,7 @@
 				},
 				{
 					"name": "int_one",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -935,7 +935,7 @@
 				},
 				{
 					"name": "int_two",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -950,7 +950,7 @@
 				},
 				{
 					"name": "int_three",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "333333",
 					"comment": "",
@@ -965,7 +965,7 @@
 				},
 				{
 					"name": "int_four",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "444444",
 					"comment": "",
@@ -980,7 +980,7 @@
 				},
 				{
 					"name": "int_five",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "0",
 					"comment": "",
@@ -995,7 +995,7 @@
 				},
 				{
 					"name": "int_six",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "0",
 					"comment": "",
@@ -1670,7 +1670,7 @@
 				},
 				{
 					"name": "integer_default",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "5",
 					"comment": "",
@@ -2651,7 +2651,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "nextval('users_id_seq'::regclass)",
 					"comment": "",
@@ -2739,7 +2739,7 @@
 			"columns": [
 				{
 					"name": "video_id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -2754,7 +2754,7 @@
 				},
 				{
 					"name": "tag_id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -2814,7 +2814,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "nextval('videos_id_seq'::regclass)",
 					"comment": "",
@@ -2829,7 +2829,7 @@
 				},
 				{
 					"name": "user_id",
-					"type": "int",
+					"type": "int32",
 					"db_type": "integer",
 					"default": "",
 					"comment": "",
@@ -2844,7 +2844,7 @@
 				},
 				{
 					"name": "sponsor_id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -2925,7 +2925,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3585,7 +3585,7 @@
 				},
 				{
 					"name": "int_zero",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3600,7 +3600,7 @@
 				},
 				{
 					"name": "int_one",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3615,7 +3615,7 @@
 				},
 				{
 					"name": "int_two",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3630,7 +3630,7 @@
 				},
 				{
 					"name": "int_three",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3645,7 +3645,7 @@
 				},
 				{
 					"name": "int_four",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3660,7 +3660,7 @@
 				},
 				{
 					"name": "int_five",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -3675,7 +3675,7 @@
 				},
 				{
 					"name": "int_six",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -4350,7 +4350,7 @@
 				},
 				{
 					"name": "integer_default",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -5326,7 +5326,7 @@
 			"columns": [
 				{
 					"name": "id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -5986,7 +5986,7 @@
 				},
 				{
 					"name": "int_zero",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6001,7 +6001,7 @@
 				},
 				{
 					"name": "int_one",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6016,7 +6016,7 @@
 				},
 				{
 					"name": "int_two",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6031,7 +6031,7 @@
 				},
 				{
 					"name": "int_three",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6046,7 +6046,7 @@
 				},
 				{
 					"name": "int_four",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6061,7 +6061,7 @@
 				},
 				{
 					"name": "int_five",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6076,7 +6076,7 @@
 				},
 				{
 					"name": "int_six",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -6751,7 +6751,7 @@
 				},
 				{
 					"name": "integer_default",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -7727,7 +7727,7 @@
 			"columns": [
 				{
 					"name": "user_id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -7742,7 +7742,7 @@
 				},
 				{
 					"name": "video_id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",
@@ -7757,7 +7757,7 @@
 				},
 				{
 					"name": "sponsor_id",
-					"type": "null.Int",
+					"type": "null.Int32",
 					"db_type": "integer",
 					"default": "NULL",
 					"comment": "",

--- a/drivers/sqlboiler-psql/driver/psql_translate_test.go
+++ b/drivers/sqlboiler-psql/driver/psql_translate_test.go
@@ -1,0 +1,99 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/aarondl/sqlboiler/v4/drivers"
+)
+
+func TestTranslateColumnType(t *testing.T) {
+	p := PostgresDriver{}
+
+	tests := []struct {
+		name     string
+		input    drivers.Column
+		wantType string
+	}{
+		// integer / serial (int4) -> int32
+		{name: "integer non-null", input: drivers.Column{DBType: "integer"}, wantType: "int32"},
+		{name: "serial non-null", input: drivers.Column{DBType: "serial"}, wantType: "int32"},
+		{name: "integer nullable", input: drivers.Column{DBType: "integer", Nullable: true}, wantType: "null.Int32"},
+		{name: "serial nullable", input: drivers.Column{DBType: "serial", Nullable: true}, wantType: "null.Int32"},
+
+		// bigint / bigserial (int8) -> int64
+		{name: "bigint non-null", input: drivers.Column{DBType: "bigint"}, wantType: "int64"},
+		{name: "bigserial non-null", input: drivers.Column{DBType: "bigserial"}, wantType: "int64"},
+		{name: "bigint nullable", input: drivers.Column{DBType: "bigint", Nullable: true}, wantType: "null.Int64"},
+
+		// smallint / smallserial (int2) -> int16
+		{name: "smallint non-null", input: drivers.Column{DBType: "smallint"}, wantType: "int16"},
+		{name: "smallserial non-null", input: drivers.Column{DBType: "smallserial"}, wantType: "int16"},
+		{name: "smallint nullable", input: drivers.Column{DBType: "smallint", Nullable: true}, wantType: "null.Int16"},
+
+		// oid -> uint32
+		{name: "oid non-null", input: drivers.Column{DBType: "oid"}, wantType: "uint32"},
+		{name: "oid nullable", input: drivers.Column{DBType: "oid", Nullable: true}, wantType: "null.Uint32"},
+
+		// decimal / numeric -> types.Decimal
+		{name: "decimal non-null", input: drivers.Column{DBType: "decimal"}, wantType: "types.Decimal"},
+		{name: "numeric non-null", input: drivers.Column{DBType: "numeric"}, wantType: "types.Decimal"},
+		{name: "decimal nullable", input: drivers.Column{DBType: "decimal", Nullable: true}, wantType: "types.NullDecimal"},
+
+		// double precision -> float64
+		{name: "double precision non-null", input: drivers.Column{DBType: "double precision"}, wantType: "float64"},
+		{name: "double precision nullable", input: drivers.Column{DBType: "double precision", Nullable: true}, wantType: "null.Float64"},
+
+		// real -> float32
+		{name: "real non-null", input: drivers.Column{DBType: "real"}, wantType: "float32"},
+		{name: "real nullable", input: drivers.Column{DBType: "real", Nullable: true}, wantType: "null.Float32"},
+
+		// text -> string
+		{name: "text non-null", input: drivers.Column{DBType: "text"}, wantType: "string"},
+		{name: "text nullable", input: drivers.Column{DBType: "text", Nullable: true}, wantType: "null.String"},
+
+		// uuid -> string (also covers character varying, cidr, inet, etc.)
+		{name: "uuid non-null", input: drivers.Column{DBType: "uuid"}, wantType: "string"},
+		{name: "uuid nullable", input: drivers.Column{DBType: "uuid", Nullable: true}, wantType: "null.String"},
+
+		// "char" -> types.Byte
+		{name: `"char" non-null`, input: drivers.Column{DBType: `"char"`}, wantType: "types.Byte"},
+		{name: `"char" nullable`, input: drivers.Column{DBType: `"char"`, Nullable: true}, wantType: "null.Byte"},
+
+		// bytea -> []byte
+		{name: "bytea non-null", input: drivers.Column{DBType: "bytea"}, wantType: "[]byte"},
+		{name: "bytea nullable", input: drivers.Column{DBType: "bytea", Nullable: true}, wantType: "null.Bytes"},
+
+		// json / jsonb -> types.JSON
+		{name: "json non-null", input: drivers.Column{DBType: "json"}, wantType: "types.JSON"},
+		{name: "jsonb non-null", input: drivers.Column{DBType: "jsonb"}, wantType: "types.JSON"},
+		{name: "json nullable", input: drivers.Column{DBType: "json", Nullable: true}, wantType: "null.JSON"},
+
+		// boolean -> bool
+		{name: "boolean non-null", input: drivers.Column{DBType: "boolean"}, wantType: "bool"},
+		{name: "boolean nullable", input: drivers.Column{DBType: "boolean", Nullable: true}, wantType: "null.Bool"},
+
+		// timestamp -> time.Time
+		{name: "timestamp without time zone non-null", input: drivers.Column{DBType: "timestamp without time zone"}, wantType: "time.Time"},
+		{name: "timestamp without time zone nullable", input: drivers.Column{DBType: "timestamp without time zone", Nullable: true}, wantType: "null.Time"},
+		{name: "timestamp with time zone non-null", input: drivers.Column{DBType: "timestamp with time zone"}, wantType: "time.Time"},
+
+		// USER-DEFINED -> hstore / citext
+		{name: "hstore non-null", input: drivers.Column{DBType: "USER-DEFINED", UDTName: "hstore"}, wantType: "types.HStore"},
+		{name: "citext non-null", input: drivers.Column{DBType: "USER-DEFINED", UDTName: "citext"}, wantType: "string"},
+		{name: "citext nullable", input: drivers.Column{DBType: "USER-DEFINED", UDTName: "citext", Nullable: true}, wantType: "null.String"},
+
+		// unknown type -> string / null.String
+		{name: "unknown non-null", input: drivers.Column{DBType: "unknown_type"}, wantType: "string"},
+		{name: "unknown nullable", input: drivers.Column{DBType: "unknown_type", Nullable: true}, wantType: "null.String"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.TranslateColumnType(tt.input)
+			if got.Type != tt.wantType {
+				t.Errorf("TranslateColumnType(%q, nullable=%v) = %q, want %q",
+					tt.input.DBType, tt.input.Nullable, got.Type, tt.wantType)
+			}
+		})
+	}
+}

--- a/queries/query_test.go
+++ b/queries/query_test.go
@@ -93,7 +93,7 @@ func TestAppendWhere(t *testing.T) {
 		t.Errorf("Expected %s, got %#v", expect, q.where)
 	}
 
-	if len(q.where[0].args) != 2 || len(q.where[0].args) != 2 {
+	if len(q.where[0].args) != 2 || len(q.where[1].args) != 2 {
 		t.Errorf("arg length wrong: %#v", q.where)
 	}
 
@@ -168,7 +168,7 @@ func TestAppendIn(t *testing.T) {
 		t.Errorf("Expected %s, got %#v", expect, q.where)
 	}
 
-	if len(q.where[0].args) != 2 || len(q.where[0].args) != 2 {
+	if len(q.where[0].args) != 2 || len(q.where[1].args) != 2 {
 		t.Errorf("arg length wrong: %#v", q.where)
 	}
 


### PR DESCRIPTION
## Summary

PostgreSQL's `integer` type is always 4 bytes (int4), but it was previously mapped to Go's platform-dependent `int`/`null.Int`. This PR fixes the mapping to use the explicit `int32`/`null.Int32` types, which accurately reflects the actual size of the column.

## Changes

- **`psql.go`**: Change the Go type for `integer`/`serial` from `int` → `int32` and `null.Int` → `null.Int32`
- **`psql.golden.json`, `psql.golden.enums.json`**: Update golden files to reflect the corrected type mapping
- **`psql_translate_test.go`**: Add `TestTranslateColumnType` covering all major PostgreSQL type mappings (integers, floats, text, boolean, timestamps, json, bytea, USER-DEFINED, etc.)
- **`queries/query_test.go`**: Fix a pre-existing typo where `where[0].args` was checked twice instead of also checking `where[1].args`. This bug was latent until Go 1.25+ enabled the corresponding `go vet` check (`redundant or`), causing CI to fail.

## Motivation

Using `int` for a 4-byte PostgreSQL column is incorrect on 64-bit platforms where `int` is 8 bytes. This mismatch can cause subtle issues with serialization, type assertions, and code that relies on the specific width of the generated type. `int32` is the correct and unambiguous representation.

## Related

Related to #1464
