### PR TITLE
fix(sqlite3): support relative path for dbname

### DIFF
--- a/drivers/sqlboiler-sqlite3/driver/sqlite3.go
+++ b/drivers/sqlboiler-sqlite3/driver/sqlite3.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strings"
 
 	_ "modernc.org/sqlite"
@@ -73,6 +74,13 @@ func (s SQLiteDriver) Assemble(config drivers.Config) (dbinfo *drivers.DBInfo, e
 	whitelist, _ := config.StringSlice(drivers.ConfigWhitelist)
 	blacklist, _ := config.StringSlice(drivers.ConfigBlacklist)
 	concurrency := config.DefaultInt(drivers.ConfigConcurrency, drivers.DefaultConcurrency)
+
+	if !filepath.IsAbs(dbname) {
+		dbname, err = filepath.Abs(dbname)
+		if err != nil {
+			return nil, fmt.Errorf("sqlboiler-sqlite failed to resolve database path: %w", err)
+		}
+	}
 
 	s.connStr = SQLiteBuildQueryString(dbname)
 	s.configForeignKeys = config.MustForeignKeys(drivers.ConfigForeignKeys)

--- a/drivers/sqlboiler-sqlite3/driver/sqlite3_test.go
+++ b/drivers/sqlboiler-sqlite3/driver/sqlite3_test.go
@@ -12,14 +12,27 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/aarondl/sqlboiler/v4/drivers"
+	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
 )
 
 var (
 	flagOverwriteGolden = flag.Bool("overwrite-golden", false, "Overwrite the golden file with the current execution results")
 )
+
+func createSQLiteDB(t *testing.T, path string, sql []byte) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	cmd := exec.Command("sqlite3", path)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	cmd.Stdin = bytes.NewReader(sql)
+	if err := cmd.Run(); err != nil {
+		t.Logf("sqlite output:\n%s\n", out.Bytes())
+		t.Fatal(err)
+	}
+}
 
 func TestDriver(t *testing.T) {
 	rand.New(rand.NewSource(time.Now().Unix()))
@@ -29,19 +42,21 @@ func TestDriver(t *testing.T) {
 	}
 
 	tmpName := filepath.Join(os.TempDir(), fmt.Sprintf("sqlboiler-sqlite3-%d.sql", rand.Int()))
-
-	out := &bytes.Buffer{}
-	createDB := exec.Command("sqlite3", tmpName)
-	createDB.Stdout = out
-	createDB.Stderr = out
-	createDB.Stdin = bytes.NewReader(b)
-
+	createSQLiteDB(t, tmpName, b)
 	t.Log("sqlite file:", tmpName)
-	if err := createDB.Run(); err != nil {
-		t.Logf("sqlite output:\n%s\n", out.Bytes())
+
+	cwd, err := os.Getwd()
+	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("sqlite output:\n%s\n", out.Bytes())
+	relName, err := filepath.Rel(cwd, tmpName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localName := fmt.Sprintf("./sqlboiler-sqlite3-local-%d.sql", rand.Int())
+	createSQLiteDB(t, localName, b)
+	t.Cleanup(func() { os.Remove(localName) })
 
 	tests := []struct {
 		name       string
@@ -49,9 +64,23 @@ func TestDriver(t *testing.T) {
 		goldenJson string
 	}{
 		{
-			name: "default",
+			name: "absolute_path",
 			config: drivers.Config{
 				"dbname": tmpName,
+			},
+			goldenJson: "sqlite3.golden.json",
+		},
+		{
+			name: "relative_path",
+			config: drivers.Config{
+				"dbname": relName,
+			},
+			goldenJson: "sqlite3.golden.json",
+		},
+		{
+			name: "relative_path_dot_slash",
+			config: drivers.Config{
+				"dbname": localName,
 			},
 			goldenJson: "sqlite3.golden.json",
 		},


### PR DESCRIPTION
## Summary

- Users can now specify a relative path (e.g. `./mydb.sqlite`) for `dbname` in `sqlboiler.toml`
- In `Assemble`, the `dbname` is resolved to an absolute path via `filepath.Abs()` before building the connection string

## Problem

When a relative path was given as `dbname`, SQLite resolved it against the working directory at the time of execution. Since the working directory when running sqlboiler differs from the one used when running generated tests, the same relative path pointed to different locations, causing `no such table` errors.

## Changes

**`drivers/sqlboiler-sqlite3/driver/sqlite3.go`**

- Resolve `dbname` to an absolute path with `filepath.Abs()` if it is not already absolute

**`drivers/sqlboiler-sqlite3/driver/sqlite3_test.go`**

- Extract DB creation logic into a `createSQLiteDB` helper
- Add test cases for each path format:

| Test case                 | Path format              | Example                          | `filepath.IsAbs()` | Resolved by `filepath.Abs()` |
| ------------------------- | ------------------------ | -------------------------------- | :----------------: | :--------------------------: |
| `absolute_path`           | Absolute path            | `/var/folders/.../mydb.sql`      |   `true` (no-op)   |              -               |
| `relative_path`           | Relative path with `../` | `../../var/folders/.../mydb.sql` |      `false`       |             yes              |
| `relative_path_dot_slash` | Relative path with `./`  | `./mydb.sql`                     |      `false`       |             yes              |

## Related issue

Related to #1409
