### PR TITLE
Optimize eager loads

### DIFF
--- a/importers/imports.go
+++ b/importers/imports.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cast"
 
-	"github.com/friendsofgo/errors"
 	"github.com/aarondl/strmangle"
+	"github.com/friendsofgo/errors"
 )
 
 // Collection of imports for various templating purposes
@@ -223,6 +223,7 @@ func NewDefaultImports() Collection {
 		"boil_types": {
 			Standard: List{
 				`"strconv"`,
+				`"database/sql/driver"`,
 			},
 			ThirdParty: List{
 				`"github.com/friendsofgo/errors"`,

--- a/templates/main/07_relationship_to_one_eager.go.tpl
+++ b/templates/main/07_relationship_to_one_eager.go.tpl
@@ -138,26 +138,50 @@ func ({{$ltable.DownSingular}}L) Load{{$rel.Foreign}}({{if $.NoContext}}e boil.E
 		return nil
 	}
 
-	for _, local := range slice {
-		for _, foreign := range resultSlice {
-			{{if $usesPrimitives -}}
-			if local.{{$col}} == foreign.{{$fcol}} {
-			{{else -}}
-			if queries.Equal(local.{{$col}}, foreign.{{$fcol}}) {
-			{{end -}}
-				local.R.{{$rel.Foreign}} = foreign
-				{{if not $.NoBackReferencing -}}
-				if foreign.R == nil {
-					foreign.R = &{{$ftable.DownSingular}}R{}
-				}
-					{{if $fkey.Unique -}}
-				foreign.R.{{$rel.Local}} = local
-					{{else -}}
-				foreign.R.{{$rel.Local}} = append(foreign.R.{{$rel.Local}}, local)
-					{{end -}}
-				{{end -}}
-				break
+	resultMap := make(map[string]*{{$ftable.UpSingular}})
+	for _, r := range resultSlice {
+		{{if $usesPrimitives -}}
+		resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = r
+		{{else -}}
+		if valuer, ok := any(r.{{$fcol}}).(Valuer); ok {
+			val, _ := valuer.Value()
+			if val != nil {
+				resultMap[fmt.Sprintf("%v", val)] = r
 			}
+		} else {
+			resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = r
+		}
+		{{end -}}
+	}
+
+	for _, local := range slice {
+		var localKey string
+		{{if $usesPrimitives -}}
+		localKey = fmt.Sprintf("%v", local.{{$col}})
+		{{else -}}
+		if valuer, ok := any(local.{{$col}}).(Valuer); ok {
+			val, _ := valuer.Value()
+			if val == nil {
+				continue
+			}
+			localKey = fmt.Sprintf("%v", val)
+		} else {
+			localKey = fmt.Sprintf("%v", local.{{$col}})
+		}
+		{{end -}}
+
+		if foreign, ok := resultMap[localKey]; ok {
+			local.R.{{$rel.Foreign}} = foreign
+			{{if not $.NoBackReferencing -}}
+			if foreign.R == nil {
+				foreign.R = &{{$ftable.DownSingular}}R{}
+			}
+			{{if $fkey.Unique -}}
+			foreign.R.{{$rel.Local}} = local
+			{{else -}}
+			foreign.R.{{$rel.Local}} = append(foreign.R.{{$rel.Local}}, local)
+			{{end -}}
+			{{end -}}
 		}
 	}
 

--- a/templates/main/08_relationship_one_to_one_eager.go.tpl
+++ b/templates/main/08_relationship_one_to_one_eager.go.tpl
@@ -119,24 +119,49 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 		}
 		foreign.R.{{$relAlias.Foreign}} = object
 		{{end -}}
+		return nil
+	}
+
+	resultMap := make(map[string]*{{$ftable.UpSingular}})
+	for _, r := range resultSlice {
+		{{if $usesPrimitives -}}
+		resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = r
+		{{else -}}
+		if valuer, ok := any(r.{{$fcol}}).(Valuer); ok {
+			val, _ := valuer.Value()
+			if val != nil {
+				resultMap[fmt.Sprintf("%v", val)] = r
+			}
+		} else {
+			resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = r
+		}
+		{{end -}}
 	}
 
 	for _, local := range slice {
-		for _, foreign := range resultSlice {
-			{{if $usesPrimitives -}}
-			if local.{{$col}} == foreign.{{$fcol}} {
-			{{else -}}
-			if queries.Equal(local.{{$col}}, foreign.{{$fcol}}) {
-			{{end -}}
-				local.R.{{$relAlias.Local}} = foreign
-				{{if not $.NoBackReferencing -}}
-				if foreign.R == nil {
-					foreign.R = &{{$ftable.DownSingular}}R{}
-				}
-				foreign.R.{{$relAlias.Foreign}} = local
-				{{end -}}
-				break
+		var localKey string
+		{{if $usesPrimitives -}}
+		localKey = fmt.Sprintf("%v", local.{{$col}})
+		{{else -}}
+		if valuer, ok := any(local.{{$col}}).(Valuer); ok {
+			val, _ := valuer.Value()
+			if val == nil {
+				continue
 			}
+			localKey = fmt.Sprintf("%v", val)
+		} else {
+			localKey = fmt.Sprintf("%v", local.{{$col}})
+		}
+		{{end -}}
+
+		if foreign, ok := resultMap[localKey]; ok {
+			local.R.{{$relAlias.Local}} = foreign
+			{{if not $.NoBackReferencing -}}
+			if foreign.R == nil {
+				foreign.R = &{{$ftable.DownSingular}}R{}
+			}
+			foreign.R.{{$relAlias.Foreign}} = local
+			{{end -}}
 		}
 	}
 

--- a/templates/main/09_relationship_to_many_eager.go.tpl
+++ b/templates/main/09_relationship_to_many_eager.go.tpl
@@ -99,11 +99,12 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 	}
 
 	var resultSlice []*{{$ftable.UpSingular}}
+	resultMap := make(map[string][]*{{$ftable.UpSingular}})
+
 	{{if .ToJoinTable -}}
 	{{- $foreignTable := getTable $.Tables .ForeignTable -}}
 	{{- $joinTable := getTable $.Tables .JoinTable -}}
 	{{- $localCol := $joinTable.GetColumn .JoinLocalColumn}}
-	var localJoinCols []{{$localCol.Type}}
 	for results.Next() {
 		one := new({{$ftable.UpSingular}})
 		var localJoinCol {{$localCol.Type}}
@@ -117,11 +118,26 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 		}
 
 		resultSlice = append(resultSlice, one)
-		localJoinCols = append(localJoinCols, localJoinCol)
+		resultMap[fmt.Sprintf("%v", localJoinCol)] = append(resultMap[fmt.Sprintf("%v", localJoinCol)], one)
 	}
 	{{- else -}}
 	if err = queries.Bind(results, &resultSlice); err != nil {
 		return errors.Wrap(err, "failed to bind eager loaded slice {{.ForeignTable}}")
+	}
+
+	for _, r := range resultSlice {
+		{{if $usesPrimitives -}}
+		resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = append(resultMap[fmt.Sprintf("%v", r.{{$fcol}})], r)
+		{{else -}}
+		if valuer, ok := any(r.{{$fcol}}).(Valuer); ok {
+			val, _ := valuer.Value()
+			if val != nil {
+				resultMap[fmt.Sprintf("%v", val)] = append(resultMap[fmt.Sprintf("%v", val)], r)
+			}
+		} else {
+			resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = append(resultMap[fmt.Sprintf("%v", r.{{$fcol}})], r)
+		}
+		{{end -}}
 	}
 	{{- end}}
 
@@ -159,46 +175,42 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 		return nil
 	}
 
-	{{if .ToJoinTable -}}
-	for i, foreign := range resultSlice {
-		localJoinCol := localJoinCols[i]
-		for _, local := range slice {
-			{{if $usesPrimitives -}}
-			if local.{{$col}} == localJoinCol {
-			{{else -}}
-			if queries.Equal(local.{{$col}}, localJoinCol) {
-			{{end -}}
-				local.R.{{$relAlias.Local}} = append(local.R.{{$relAlias.Local}}, foreign)
-				{{if not $.NoBackReferencing -}}
-				if foreign.R == nil {
-					foreign.R = &{{$ftable.DownSingular}}R{}
-				}
-				foreign.R.{{$relAlias.Foreign}} = append(foreign.R.{{$relAlias.Foreign}}, local)
-				{{end -}}
-				break
+	for _, local := range slice {
+		var localKey string
+		{{if $usesPrimitives -}}
+		localKey = fmt.Sprintf("%v", local.{{$col}})
+		{{else -}}
+		if valuer, ok := any(local.{{$col}}).(Valuer); ok {
+			val, _ := valuer.Value()
+			if val == nil {
+				continue
 			}
+			localKey = fmt.Sprintf("%v", val)
+		} else {
+			localKey = fmt.Sprintf("%v", local.{{$col}})
 		}
-	}
-	{{else -}}
-	for _, foreign := range resultSlice {
-		for _, local := range slice {
-			{{if $usesPrimitives -}}
-			if local.{{$col}} == foreign.{{$fcol}} {
-			{{else -}}
-			if queries.Equal(local.{{$col}}, foreign.{{$fcol}}) {
-			{{end -}}
-				local.R.{{$relAlias.Local}} = append(local.R.{{$relAlias.Local}}, foreign)
-				{{if not $.NoBackReferencing -}}
-				if foreign.R == nil {
-					foreign.R = &{{$ftable.DownSingular}}R{}
-				}
-				foreign.R.{{$relAlias.Foreign}} = local
-				{{end -}}
-				break
+		{{end -}}
+
+		others := resultMap[localKey]
+		if len(others) == 0 {
+			continue
+		}
+
+		local.R.{{$relAlias.Local}} = append(local.R.{{$relAlias.Local}}, others...)
+
+		{{if not $.NoBackReferencing -}}
+		for _, foreign := range others {
+			if foreign.R == nil {
+				foreign.R = &{{$ftable.DownSingular}}R{}
 			}
+			{{if .ToJoinTable -}}
+			foreign.R.{{$relAlias.Foreign}} = append(foreign.R.{{$relAlias.Foreign}}, local)
+			{{else -}}
+			foreign.R.{{$relAlias.Foreign}} = local
+			{{end -}}
 		}
+		{{end -}}
 	}
-	{{end}}
 
 	return nil
 }

--- a/templates/main/singleton/boil_types.go.tpl
+++ b/templates/main/singleton/boil_types.go.tpl
@@ -1,3 +1,6 @@
+// Valuer is a type alias for database/sql/driver used for type assertion (e.g. in eager loading optimization).
+type Valuer = driver.Valuer
+
 // M type is for providing columns and column values to UpdateAll.
 type M map[string]any
 


### PR DESCRIPTION
Currently, eager loading of relationships uses nested loops, which results in O(n^2) behavior.
For large datasets, this can significantly hurt performance.

I replaced the nested-loop matching with map-based lookups.
After the results are bound, a lookup map is populated from the relevant relationship key values.
Primitive values are normalized with `fmt.Sprintf`, while nullable values, especially `null.XXX` structs, are converted through the `database/sql/driver.Valuer` interface.

This ensures that nullable foreign key fields are matched correctly while preserving the existing eager-loading behavior.

Please let my know if anything is missing!