### PR TITLE
Optimize eager loads map key generation

### DIFF
--- a/importers/imports.go
+++ b/importers/imports.go
@@ -222,6 +222,7 @@ func NewDefaultImports() Collection {
 		},
 		"boil_types": {
 			Standard: List{
+				`"fmt"`,
 				`"strconv"`,
 				`"database/sql/driver"`,
 			},

--- a/templates/main/07_relationship_to_one_eager.go.tpl
+++ b/templates/main/07_relationship_to_one_eager.go.tpl
@@ -77,12 +77,12 @@ func ({{$ltable.DownSingular}}L) Load{{$rel.Foreign}}({{if $.NoContext}}e boil.E
 	}
 
 	query := NewQuery(
-	    qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),
-	    qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, argsSlice...),
-	    {{if and $.AddSoftDeletes $canSoftDelete -}}
-	    qmhelper.WhereIsNull(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{or $.AutoColumns.Deleted "deleted_at"}}`),
-	    {{- end}}
-    )
+		qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),
+		qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, argsSlice...),
+		{{if and $.AddSoftDeletes $canSoftDelete -}}
+		qmhelper.WhereIsNull(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{or $.AutoColumns.Deleted "deleted_at"}}`),
+		{{- end}}
+	)
 	if mods != nil {
 		mods.Apply(query)
 	}

--- a/templates/main/07_relationship_to_one_eager.go.tpl
+++ b/templates/main/07_relationship_to_one_eager.go.tpl
@@ -140,37 +140,11 @@ func ({{$ltable.DownSingular}}L) Load{{$rel.Foreign}}({{if $.NoContext}}e boil.E
 
 	resultMap := make(map[string]*{{$ftable.UpSingular}})
 	for _, r := range resultSlice {
-		{{if $usesPrimitives -}}
-		resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = r
-		{{else -}}
-		if valuer, ok := any(r.{{$fcol}}).(Valuer); ok {
-			val, _ := valuer.Value()
-			if val != nil {
-				resultMap[fmt.Sprintf("%v", val)] = r
-			}
-		} else {
-			resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = r
-		}
-		{{end -}}
+		resultMap[generateMapKey(r.{{$fcol}})] = r
 	}
 
 	for _, local := range slice {
-		var localKey string
-		{{if $usesPrimitives -}}
-		localKey = fmt.Sprintf("%v", local.{{$col}})
-		{{else -}}
-		if valuer, ok := any(local.{{$col}}).(Valuer); ok {
-			val, _ := valuer.Value()
-			if val == nil {
-				continue
-			}
-			localKey = fmt.Sprintf("%v", val)
-		} else {
-			localKey = fmt.Sprintf("%v", local.{{$col}})
-		}
-		{{end -}}
-
-		if foreign, ok := resultMap[localKey]; ok {
+		if foreign, ok := resultMap[generateMapKey(local.{{$col}})]; ok {
 			local.R.{{$rel.Foreign}} = foreign
 			{{if not $.NoBackReferencing -}}
 			if foreign.R == nil {

--- a/templates/main/08_relationship_one_to_one_eager.go.tpl
+++ b/templates/main/08_relationship_one_to_one_eager.go.tpl
@@ -124,37 +124,11 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 
 	resultMap := make(map[string]*{{$ftable.UpSingular}})
 	for _, r := range resultSlice {
-		{{if $usesPrimitives -}}
-		resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = r
-		{{else -}}
-		if valuer, ok := any(r.{{$fcol}}).(Valuer); ok {
-			val, _ := valuer.Value()
-			if val != nil {
-				resultMap[fmt.Sprintf("%v", val)] = r
-			}
-		} else {
-			resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = r
-		}
-		{{end -}}
+		resultMap[generateMapKey(r.{{$fcol}})] = r
 	}
 
 	for _, local := range slice {
-		var localKey string
-		{{if $usesPrimitives -}}
-		localKey = fmt.Sprintf("%v", local.{{$col}})
-		{{else -}}
-		if valuer, ok := any(local.{{$col}}).(Valuer); ok {
-			val, _ := valuer.Value()
-			if val == nil {
-				continue
-			}
-			localKey = fmt.Sprintf("%v", val)
-		} else {
-			localKey = fmt.Sprintf("%v", local.{{$col}})
-		}
-		{{end -}}
-
-		if foreign, ok := resultMap[localKey]; ok {
+		if foreign, ok := resultMap[generateMapKey(local.{{$col}})]; ok {
 			local.R.{{$relAlias.Local}} = foreign
 			{{if not $.NoBackReferencing -}}
 			if foreign.R == nil {

--- a/templates/main/08_relationship_one_to_one_eager.go.tpl
+++ b/templates/main/08_relationship_one_to_one_eager.go.tpl
@@ -65,12 +65,12 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 	}
 
 	query := NewQuery(
-	    qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),
-        qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, argsSlice...),
-	    {{if and $.AddSoftDeletes $canSoftDelete -}}
-	    qmhelper.WhereIsNull(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{or $.AutoColumns.Deleted "deleted_at"}}`),
-	    {{- end}}
-    )
+		qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),
+		qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, argsSlice...),
+		{{if and $.AddSoftDeletes $canSoftDelete -}}
+		qmhelper.WhereIsNull(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{or $.AutoColumns.Deleted "deleted_at"}}`),
+		{{- end}}
+	)
 	if mods != nil {
 		mods.Apply(query)
 	}

--- a/templates/main/09_relationship_to_many_eager.go.tpl
+++ b/templates/main/09_relationship_to_many_eager.go.tpl
@@ -78,12 +78,12 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 	)
 		{{else -}}
 	query := NewQuery(
-	    qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),
-	    qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, argsSlice...),
-	    {{if and $.AddSoftDeletes $canSoftDelete -}}
-	    qmhelper.WhereIsNull(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{or $.AutoColumns.Deleted "deleted_at"}}`),
-	    {{- end}}
-    )
+		qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),
+		qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, argsSlice...),
+		{{if and $.AddSoftDeletes $canSoftDelete -}}
+		qmhelper.WhereIsNull(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{or $.AutoColumns.Deleted "deleted_at"}}`),
+		{{- end}}
+	)
 		{{end -}}
 	if mods != nil {
 		mods.Apply(query)

--- a/templates/main/09_relationship_to_many_eager.go.tpl
+++ b/templates/main/09_relationship_to_many_eager.go.tpl
@@ -126,18 +126,8 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 	}
 
 	for _, r := range resultSlice {
-		{{if $usesPrimitives -}}
-		resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = append(resultMap[fmt.Sprintf("%v", r.{{$fcol}})], r)
-		{{else -}}
-		if valuer, ok := any(r.{{$fcol}}).(Valuer); ok {
-			val, _ := valuer.Value()
-			if val != nil {
-				resultMap[fmt.Sprintf("%v", val)] = append(resultMap[fmt.Sprintf("%v", val)], r)
-			}
-		} else {
-			resultMap[fmt.Sprintf("%v", r.{{$fcol}})] = append(resultMap[fmt.Sprintf("%v", r.{{$fcol}})], r)
-		}
-		{{end -}}
+		key := generateMapKey(r.{{$fcol}})
+		resultMap[key] = append(resultMap[key], r)
 	}
 	{{- end}}
 
@@ -176,22 +166,7 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 	}
 
 	for _, local := range slice {
-		var localKey string
-		{{if $usesPrimitives -}}
-		localKey = fmt.Sprintf("%v", local.{{$col}})
-		{{else -}}
-		if valuer, ok := any(local.{{$col}}).(Valuer); ok {
-			val, _ := valuer.Value()
-			if val == nil {
-				continue
-			}
-			localKey = fmt.Sprintf("%v", val)
-		} else {
-			localKey = fmt.Sprintf("%v", local.{{$col}})
-		}
-		{{end -}}
-
-		others := resultMap[localKey]
+		others := resultMap[generateMapKey(local.{{$col}})]
 		if len(others) == 0 {
 			continue
 		}

--- a/templates/main/singleton/boil_types.go.tpl
+++ b/templates/main/singleton/boil_types.go.tpl
@@ -1,6 +1,3 @@
-// Valuer is a type alias for database/sql/driver used for type assertion (e.g. in eager loading optimization).
-type Valuer = driver.Valuer
-
 // M type is for providing columns and column values to UpdateAll.
 type M map[string]any
 
@@ -39,6 +36,59 @@ func makeCacheKey(cols boil.Columns, nzDefaults []string) string {
 	str := buf.String()
 	strmangle.PutBuffer(buf)
 	return str
+}
+
+// generateMapKey converts a database key value to its string representation.
+func generateMapKey(value any) string {
+	switch v := value.(type) {
+	// string
+	case string:
+		return v
+
+	// byte slice
+	case []byte:
+		return string(v)
+
+	// integers
+	case int:
+		return strconv.Itoa(v)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+
+	// float: uncommon as DB keys but supported for completeness
+	case float32:
+		return strconv.FormatFloat(float64(v), 'g', -1, 32)
+	case float64:
+		return strconv.FormatFloat(v, 'g', -1, 64)
+
+	// sql driver.Valuer: unwrap and recurse on the underlying value
+	case driver.Valuer:
+		valuerValue, err := v.Value()
+		if err != nil || valuerValue == nil {
+			return ""
+		}
+		return generateMapKey(valuerValue)
+
+	// fallback for other types
+	default:
+		return fmt.Sprintf("%v", value)
+	}
 }
 
 {{/*


### PR DESCRIPTION
Following up on #1473, I improved the map key generation logic.

Primitive values, strings and byte slices in particular, no longer go through `fmt.Sprintf`, which reduces overhead. Numeric values are now handled by the `strconv` package, which is faster and produces fewer allocations.

SQL `driver.Valuer` types are unwrapped directly inside `generateMapKey`, which keeps the generated eager-loading code more readable and concise.

`generateMapKey` handles the typical data types used as database keys efficiently, with a best-effort `fmt.Sprintf` fallback for unrecognized types.

Let me know, if anything is missing!

